### PR TITLE
Updates delete function and get pages functions

### DIFF
--- a/assets/scripts/layout.js
+++ b/assets/scripts/layout.js
@@ -1,8 +1,16 @@
+const store = require('./store.js')
 
 const loadPages = (response) => {
   const pageTemplate = require('./templates/get-pages.handlebars')
   const content = pageTemplate({ pages: response.pages })
   $('#app').html(content)
+}
+
+const loadUserPages = () => {
+  const userPageTemplate = require('./templates/get-pages.handlebars')
+  const content = userPageTemplate({ pages: store.userPages })
+  $('#app').empty()
+  $('#app').append(content)
 }
 
 const loadPosts = (response) => {
@@ -13,5 +21,6 @@ const loadPosts = (response) => {
 
 module.exports = {
   loadPages,
-  loadPosts
+  loadPosts,
+  loadUserPages
 }

--- a/assets/scripts/pages/api.js
+++ b/assets/scripts/pages/api.js
@@ -25,7 +25,7 @@ const newUserPage = (data) => {
 }
 
 // THIS NEEDS TO GET A USER ID
-const getAllUserPages = () => {
+const getAllUserPages = (userId) => {
   return $.ajax({
     url: config.apiOrigin + '/pages/',
     method: 'GET',

--- a/assets/scripts/pages/ui.js
+++ b/assets/scripts/pages/ui.js
@@ -1,15 +1,25 @@
 const layout = require('../layout.js')
 const api = require('./api.js')
+const showPagesTemplate = require('../templates/get-pages.handlebars')
 const store = require('../store.js')
+const getFormFields = require(`../../../lib/get-form-fields`)
 
 const getAllPagesSuccess = (response) => {
-  console.log('success is ', response)
-  console.log(store.user)
-  console.log(store.user.id)
+  console.log(response)
   layout.loadPages(response)
 }
 
 const getAllPagesFailure = (error) => {
+  console.error(error)
+}
+
+const newUserPageSuccess = (response) => {
+  console.log(response)
+  layout.loadPages(response)
+  refreshPagesList()
+}
+
+const newUserPageFailure = (error) => {
   console.error(error)
 }
 
@@ -19,38 +29,70 @@ const getAllUserPagesSuccess = (data) => {
     return store.user.id === page._owner
   })
   console.log(store.userPages)
-  layout.loadPages(store.userPages)
-  $('.destroy-page-button').on('click', onDeletePage)
+  // console.log(data)
+  layout.loadUserPages()
+  $('.destroy-page-button').on('click', onDeleteUserPage)
+  refreshPagesList()
 }
 
 const getAllUserPagesFailure = (error) => {
   console.error(error)
 }
 
-const onDeletePage = (event) => {
+// const onUpdateUserPage = (event) => {
+//   event.preventDefault()
+//   const data = getFormFields(event.target)
+//   const updatedPage = $(event.target).attr('data-id')
+//   refreshPagesList()
+//   api.updateUserPage(data, updatedPage)
+//     .then(updateUserPageSuccess)
+//     .catch(updateUserPageFailure)
+//     .then(() => {
+//       api.getAllUserPages()
+//         .then(getAllUserPagesSuccess)
+//         .catch(getAllUserPagesFailure)
+//     })
+// }
+
+// Not sure if we want each page to be updatable when they are indexed,
+// or if we want a button to open a form to update within handlebars
+
+const refreshPagesList = (data) => {
+  const showPagesHtml = showPagesTemplate({ pages: store.pagesLists })
+  $('.content').empty()
+  $('.content').append(showPagesHtml)
+  // $('.update-page-button').on('click', onUpdateUserPage)
+  $('.destroy-page-button').on('click', onDeleteUserPage)
+}
+
+const onDeleteUserPage = (event) => {
   event.preventDefault()
-  const removePage = $(event.target).attr('data-id')
-  api.deleteUserPage(removePage)
-    .then(deletePageSuccess)
-    .catch(deletePageFailure)
+  const removeUserPage = $(event.target).attr('data-id')
+  console.log(event.target)
+  api.deleteUserPage(removeUserPage)
+    .then(deleteUserPageSuccess)
+    .catch(deleteUserPageFailure)
+    .then(() => {
+      api.getAllUserPages()
+        .then(getAllUserPagesSuccess)
+        .catch(getAllUserPagesFailure)
+    })
 }
 
-const newUserPageSuccess = (response) => {
-  console.log(response)
-  layout.loadPages(response)
+// const updateUserPageSuccess = (response) => {
+//   console.log(response)
+// }
+//
+// const updateUserPageFailure = (error) => {
+//   console.errer(error)
+// }
+
+const deleteUserPageSuccess = (response) => {
+  console.log('page deleted ', response)
 }
 
-const newUserPageFailure = (error) => {
-  console.error(error)
-}
-
-const deletePageSuccess = (response) => {
-  console.log(response)
-  layout.loadPages(response)
-}
-
-const deletePageFailure = (error) => {
-  console.error(error)
+const deleteUserPageFailure = (error) => {
+  console.error('failed ', error)
 }
 
 module.exports = {

--- a/assets/scripts/templates/get-pages.handlebars
+++ b/assets/scripts/templates/get-pages.handlebars
@@ -1,14 +1,14 @@
 <h3 class="get-pages-block">Pages</h3>
-<div data-id="{{pages.id}}" id="myUL">
-  {{#each pages as |pages|}}
+<div data-id="{{page.id}}" id="myUL">
+  {{#each pages as |page|}}
   <div>
-    <div class="pages" data-title="{{pages.title}}" data-name="{{pages.description}}" data-length={{pages.length}}>
-      <h4>Title: <a href="http://localhost:4741/pages/{{pages.id}}">{{pages.title}}</a></h4>
-      <h4>Description: {{pages.description}}</div>
+    <div class="pages" data-title="{{page.title}}" data-name="{{page.description}}" data-length={{page.length}}>
+      <h4>Title: <a href="http://localhost:4741/pages/{{page.id}}">{{page.title}}</a></h4>
+      <h4>Description: {{page.description}}</div>
     </div>
     <div>
       <br>
-      <button data-id="{{pages.id}}" id="red-button" class="btn btn-danger destroy-page-button" value="delete">delete</button>
+      <button data-id="{{page.id}}" id="red-button" class="btn btn-danger destroy-page-button" value="delete">delete</button>
     </div>
   {{/each}}
 </div>


### PR DESCRIPTION
Delete function currently only works when user gets their own pages
executing getAllUserPages.  Users cannot delete even their own pages
when executing getUserPages.

getAllUserPages now renders the pages that belong to the current user.
It does not render every page.

get-pages.handlebars is edited to change names from 'pages.title'
to 'page.title', etc...

loadUserPages is added to layout.js, which fixed the getUserPages
function.